### PR TITLE
クロスビルド用環境変数の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,6 @@ RUN mkdir armv6-rpi-linux-gnueabihf \
  && rm -rf armv6-rpi-linux-gnueabihf
 ENV PATH $HOME/x-tools/armv6-rpi-linux-gnueabihf/bin:$PATH
 
+# cross compilation with rust
+ENV CC_arm_unknown_linux_gnueabihf armv6-rpi-linux-gnueabihf-gcc
+


### PR DESCRIPTION
rustのプロジェクトをarm(raspberry-pi)向けにクロスビルドするための環境変数を追加しました。
#ついでに不要な環境変数の追加コマンドを削除してあります。
