### PR TITLE
Upgrade base image to debian:bullseye, and introduce per-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
       gcc g++ cmake autoconf automake libtool libtool-bin build-essential \
       pkg-config gperf bison flex texinfo bzip2 unzip xz-utils help2man gawk \
       make libncurses5-dev libssl-dev \
-      python python-dev python-pip \
       python3 python3-dev python3-pip \
       htop apt-utils locales ca-certificates \
  && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 ARG RPI_FIRMWARE_BASE_URL='http://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware'
 ARG RPI_FIRMWARE_VERSION='20200114-1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,22 @@
-FROM debian:bullseye
+ARG DEBIAN_IMAGE_TAG=bullseye
+
+FROM debian:${DEBIAN_IMAGE_TAG} as base
 
 ARG RPI_FIRMWARE_BASE_URL='http://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware'
 ARG RPI_FIRMWARE_VERSION='20200114-1'
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
       sudo git wget curl bc asciidoc xmlto \
-      gcc g++ gcc-9 g++-9 cmake autoconf automake libtool libtool-bin build-essential \
+      gcc g++ cmake autoconf automake libtool libtool-bin build-essential \
       pkg-config gperf bison flex texinfo bzip2 unzip xz-utils help2man gawk \
       make libncurses5-dev libssl-dev \
       python3 python3-dev python3-pip \
       htop apt-utils locales ca-certificates \
- && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 \
- && update-alternatives --config gcc \
- && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9 \
- && update-alternatives --config g++ \
  && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
-
-WORKDIR /tmp
 
 RUN wget -O /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb \
          ${RPI_FIRMWARE_BASE_URL}/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb \
@@ -29,17 +25,6 @@ RUN wget -O /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb \
  && dpkg-deb -x /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb / \
  && dpkg-deb -x /tmp/libraspberrypi-dev_1.${RPI_FIRMWARE_VERSION}_armhf.deb / \
  && rm /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb /tmp/libraspberrypi-dev_1.${RPI_FIRMWARE_VERSION}_armhf.deb
-
-RUN curl -sLO http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.24.0.tar.xz \
- && tar xJf crosstool-ng-1.24.0.tar.xz \
- && cd crosstool-ng-1.24.0 \
- && sed 's|http://isl.gforge.inria.fr|https://libisl.sourceforge.io|' -i config/versions/isl.in \
- && sed 's|http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}|https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}|' -i config/versions/expat.in \
- && ./configure \
- && make \
- && make install \
- && cd .. \
- && rm -rf crosstool-ng-1.24.0 crosstool-ng-1.24.0.tar.xz
 
 # add idein user
 RUN useradd -m idein \
@@ -61,9 +46,40 @@ ENV LC_ALL en_US.UTF-8
 ENV PATH /home/idein/.local/bin:$PATH
 CMD ["/bin/bash"]
 
-# Shorten the name of a temporary directory before removing it for Docker under
-# some configurations so that it can remove deeply-nested directory.
-# See https://github.com/moby/moby/issues/13451
+
+FROM base AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /tmp
+
+RUN curl -sLO http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.24.0.tar.xz \
+ && tar xJf crosstool-ng-1.24.0.tar.xz \
+ && cd crosstool-ng-1.24.0 \
+ && sed 's|http://isl.gforge.inria.fr|https://libisl.sourceforge.io|' -i config/versions/isl.in \
+ && sed 's|http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}|https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}|' -i config/versions/expat.in \
+ && ./configure \
+ && make \
+ && sudo make install \
+ && cd .. \
+ && rm -rf crosstool-ng-1.24.0 crosstool-ng-1.24.0.tar.xz
+
+# use GCC 8 or 9 for crosstool-NG 1.24.0
+RUN . /etc/os-release \
+ && if [ "$VERSION_ID" -eq 11 ]; then \
+         sudo apt-get update \
+      && sudo apt-get install -y --no-install-recommends \
+           gcc-9 g++-9 \
+      && sudo apt-get clean \
+      && sudo rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
+      && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 \
+      && sudo update-alternatives --config gcc \
+      && sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9 \
+      && sudo update-alternatives --config g++ \
+ ;  fi
+
+
+FROM builder AS armv6-builder
 
 RUN mkdir armv6-rpi-linux-gnueabihf \
  && cd armv6-rpi-linux-gnueabihf \
@@ -76,9 +92,15 @@ RUN mkdir armv6-rpi-linux-gnueabihf \
  && sed 's/CT_LOG_PROGRESS_BAR/# CT_LOG_PROGRESS_BAR/' -i .config \
  && ct-ng build \
  && cd .. \
- && mv armv6-rpi-linux-gnueabihf waste \
- && rm -rf waste
-ENV PATH $HOME/x-tools/armv6-rpi-linux-gnueabihf/bin:$PATH
+ && rm -rf armv6-rpi-linux-gnueabihf
+
+FROM base AS armv6
+
+COPY --from=armv6-builder --chown=idein:idein $HOME/x-tools x-tools
+ENV PATH=$HOME/x-tools/armv6-rpi-linux-gnueabihf/bin:$PATH
+
+
+FROM builder AS armv7-builder
 
 RUN mkdir armv7-rpi2-linux-gnueabihf \
  && cd armv7-rpi2-linux-gnueabihf \
@@ -87,9 +109,15 @@ RUN mkdir armv7-rpi2-linux-gnueabihf \
  && sed 's/CT_LOG_PROGRESS_BAR/# CT_LOG_PROGRESS_BAR/' -i .config \
  && ct-ng build \
  && cd .. \
- && mv armv7-rpi2-linux-gnueabihf waste \
- && rm -rf waste
-ENV PATH $HOME/x-tools/armv7-rpi2-linux-gnueabihf/bin:$PATH
+ && rm -rf armv7-rpi2-linux-gnueabihf
+
+FROM base AS armv7
+
+COPY --from=armv7-builder --chown=idein:idein $HOME/x-tools x-tools
+ENV PATH=$HOME/x-tools/armv7-rpi2-linux-gnueabihf/bin:$PATH
+
+
+FROM builder AS armv8-builder
 
 RUN mkdir armv8-rpi3-linux-gnueabihf \
  && cd armv8-rpi3-linux-gnueabihf \
@@ -98,9 +126,15 @@ RUN mkdir armv8-rpi3-linux-gnueabihf \
  && sed 's/CT_LOG_PROGRESS_BAR/# CT_LOG_PROGRESS_BAR/' -i .config \
  && ct-ng build \
  && cd .. \
- && mv armv8-rpi3-linux-gnueabihf waste \
- && rm -rf waste
-ENV PATH $HOME/x-tools/armv8-rpi3-linux-gnueabihf/bin:$PATH
+ && rm -rf armv8-rpi3-linux-gnueabihf
+
+FROM base AS armv8
+
+COPY --from=armv8-builder --chown=idein:idein $HOME/x-tools x-tools
+ENV PATH=$HOME/x-tools/armv8-rpi3-linux-gnueabihf/bin:$PATH
+
+
+FROM builder AS aarch64-builder
 
 RUN mkdir aarch64-rpi3-linux-gnuhf \
  && cd aarch64-rpi3-linux-gnuhf \
@@ -110,6 +144,18 @@ RUN mkdir aarch64-rpi3-linux-gnuhf \
  && sed 's/CT_LOG_PROGRESS_BAR/# CT_LOG_PROGRESS_BAR/' -i .config \
  && ct-ng build \
  && cd .. \
- && mv aarch64-rpi3-linux-gnuhf waste \
- && rm -rf waste
-ENV PATH $HOME/x-tools/aarch64-rpi3-linux-gnuhf/bin:$PATH
+ && rm -rf aarch64-rpi3-linux-gnuhf
+
+FROM base AS aarch64
+
+COPY --from=aarch64-builder --chown=idein:idein $HOME/x-tools x-tools
+ENV PATH=$HOME/x-tools/aarch64-rpi3-linux-gnuhf/bin:$PATH
+
+
+FROM base
+
+COPY --from=armv6-builder --chown=idein:idein $HOME/x-tools x-tools
+COPY --from=armv7-builder --chown=idein:idein $HOME/x-tools x-tools
+COPY --from=armv8-builder --chown=idein:idein $HOME/x-tools x-tools
+COPY --from=aarch64-builder --chown=idein:idein $HOME/x-tools x-tools
+ENV PATH=$HOME/x-tools/armv6-rpi-linux-gnueabihf/bin:$HOME/x-tools/armv7-rpi2-linux-gnueabihf/bin:$HOME/x-tools/armv8-rpi3-linux-gnueabihf/bin:$HOME/x-tools/aarch64-rpi3-linux-gnuhf/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,15 @@ RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
       sudo git wget curl bc asciidoc xmlto \
-      gcc g++ cmake autoconf automake libtool libtool-bin build-essential \
+      gcc g++ gcc-9 g++-9 cmake autoconf automake libtool libtool-bin build-essential \
       pkg-config gperf bison flex texinfo bzip2 unzip xz-utils help2man gawk \
       make libncurses5-dev libssl-dev \
       python3 python3-dev python3-pip \
       htop apt-utils locales ca-certificates \
+ && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 \
+ && update-alternatives --config gcc \
+ && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9 \
+ && update-alternatives --config g++ \
  && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV PATH /home/idein/.local/bin:$PATH
-RUN echo "export PATH=$PATH" >> /home/idein/.bashrc
 CMD ["/bin/bash"]
 
 # Shorten the name of a temporary directory before removing it for Docker under
@@ -114,5 +113,3 @@ RUN mkdir aarch64-rpi3-linux-gnuhf \
  && mv aarch64-rpi3-linux-gnuhf waste \
  && rm -rf waste
 ENV PATH $HOME/x-tools/aarch64-rpi3-linux-gnuhf/bin:$PATH
-
-RUN echo "export PATH=$PATH" >> /home/idein/.bashrc


### PR DESCRIPTION
A slight improvement of #9.

The per-arch images are now built in separate stages, so we can generate all the images by:
```shell
for tag in buster buster-slim bullseye bullseye-slim; do
    for target in base builder armv6 armv7 armv8 aarch64; do
        docker build --build-arg DEBIAN_IMAGE_TAG=$tag --target $target --tag idein/cross-rpi:$tag-crosstool-ng-1.24.0-$target .
    done
    docker build --build-arg DEBIAN_IMAGE_TAG=$tag --tag idein/cross-rpi:$tag-crosstool-ng-1.24.0 .
done
```

@notogawa @eldesh @ishiy1993 The slim images (`buster-slim*` and `bullseye-slim*`) are now pushed to Docker Hub: https://hub.docker.com/r/idein/cross-rpi .
Can you have a try and review them?