### PR TITLE
docker内のtoolchainへのpathを変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - run:
           name: docker login
           command: |
-            echo $DOCKER_PASSWORD | docker login --password-stdin -u $DOCKER_USER
+            echo $DOCKER_PASS | docker login --password-stdin -u $DOCKER_USER
       - run:
           command: |
             sudo apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,8 @@ jobs:
             docker buildx build \
               --push \
               --platform linux/arm64,linux/amd64 \
-              --tag idein/cross-rpi:buster-crosstool-ng-1.24.0 .
+              --tag idein/cross-rpi:buster-crosstool-ng-1.24.0 \
+              --tag idein/cross-rpi:latest .
 aliases:
   filter-accept-all: &filter-accept-all
     filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,12 +78,6 @@ COPY --from=UNPACKER /tmp/armv7-rpi2-linux-gnueabihf /home/idein/x-tools/
 COPY --from=UNPACKER /tmp/armv8-rpi3-linux-gnueabihf /home/idein/x-tools/
 COPY --from=UNPACKER /tmp/aarch64-rpi3-linux-gnuhf /home/idein/x-tools/
 
-RUN sudo rm -r \
-    /home/idein/x-tools/armv6-rpi-linux-gnueabihf \
-    /home/idein/x-tools/armv7-rpi2-linux-gnueabihf \
-    /home/idein/x-tools/armv8-rpi3-linux-gnueabihf \
-    /home/idein/x-tools/aarch64-rpi3-linux-gnuhf
-
 ENV PATH $HOME/x-tools/bin:$PATH
 
 RUN echo "export PATH=$PATH" >> /home/idein/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:buster-slim AS UNPACKER
 ARG TARGETARCH
 
 WORKDIR /tmp
-
 RUN apt-get update \
     && apt-get -y install xz-utils
 
@@ -79,9 +78,12 @@ COPY --from=UNPACKER /tmp/armv7-rpi2-linux-gnueabihf /home/idein/x-tools/
 COPY --from=UNPACKER /tmp/armv8-rpi3-linux-gnueabihf /home/idein/x-tools/
 COPY --from=UNPACKER /tmp/aarch64-rpi3-linux-gnuhf /home/idein/x-tools/
 
-ENV PATH $HOME/x-tools/armv6-rpi-linux-gnueabihf/bin:$PATH
-ENV PATH $HOME/x-tools/armv7-rpi2-linux-gnueabihf/bin:$PATH
-ENV PATH $HOME/x-tools/armv8-rpi3-linux-gnueabihf/bin:$PATH
-ENV PATH $HOME/x-tools/aarch64-rpi3-linux-gnuhf/bin:$PATH
+RUN sudo rm -r \
+    /home/idein/x-tools/armv6-rpi-linux-gnueabihf \
+    /home/idein/x-tools/armv7-rpi2-linux-gnueabihf \
+    /home/idein/x-tools/armv8-rpi3-linux-gnueabihf \
+    /home/idein/x-tools/aarch64-rpi3-linux-gnuhf
+
+ENV PATH $HOME/x-tools/bin:$PATH
 
 RUN echo "export PATH=$PATH" >> /home/idein/.bashrc


### PR DESCRIPTION
`$HOME/x-tools/armv6-rpi-linux-gnueabihf/bin` の下にはprefixのついていない `ld` などのバイナリがあり、これをPATHに追加するとデフォルトのリンカが上書きされてしまっていたので修正しました
dockerイメージの中に入ると `$HOME/x-tools/bin` の下に全てのプラットフォーム向けのtoolchainがprefix付きで(armv6-rpi-linux-gnueabihf-gcc みたいな) 入っていたので、ここだけをpathに追加し、~~`$HOME/x-tools/armv6-rpi-linux-gnueabihf/` などのディレクトリは削除しました~~
（なぜ x-tools/bin 以下に入っているのかDockerfileを読んでもよくわからない）

ついでの修正として
* docker login のコマンドが間違えていたので修正
* pushするイメージにlatestタグも付与する
を行いました